### PR TITLE
NDRS-1176: Support extensible block headers

### DIFF
--- a/node/src/types/deploy.rs
+++ b/node/src/types/deploy.rs
@@ -267,6 +267,12 @@ impl From<Digest> for DeployHash {
     }
 }
 
+impl From<DeployHash> for Digest {
+    fn from(deploy_hash: DeployHash) -> Self {
+        deploy_hash.0
+    }
+}
+
 impl AsRef<[u8]> for DeployHash {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()


### PR DESCRIPTION
 - Changes block body hashing to use a Merkle-tree strategy for hashing deploy and transfer hashes